### PR TITLE
Fix notification bug for non on change types

### DIFF
--- a/functions/notifications.py
+++ b/functions/notifications.py
@@ -252,10 +252,13 @@ def check_endpoints():
                             timer_data = api_data.copy() if api_data else {}
                             timer_data.update({
                                 'value': current_value,
+                                'old_value': flow.get('last_value'),  # Include old_value for template support
                                 'api_data': api_data
                             })
                             if send_discord_notification(flow['message_template'], flow, timer_data):
                                 flow['last_run'] = now
+                                # Store current value as last_value for next run
+                                flow['last_value'] = current_value
                                 config_changed = True
                     
                     # Handle change detection flows


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `old_value` support for timer and webhook notifications to enable consistent template usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-d69da685-d8b8-43b4-b75f-b7cd9d428f51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d69da685-d8b8-43b4-b75f-b7cd9d428f51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>