### PR TITLE
Differentiate notification types or remove on change

### DIFF
--- a/endpoints/api.py
+++ b/endpoints/api.py
@@ -132,7 +132,7 @@ def init_api_routes(app):
                 'active': len(active_flows),
                 'inactive': len(flows) - len(active_flows),
                 'by_type': {
-                    'timer': len(timer_flows),
+                    'scheduled': len(timer_flows),
                     'change_detection': len(change_flows),
                     'webhook': len(webhook_flows)
                 }

--- a/functions/notifications.py
+++ b/functions/notifications.py
@@ -240,14 +240,14 @@ def check_endpoints():
                             log_notification(f"API error in {flow['name']}: {str(api_error)}")
                             continue
                     
-                    # Handle timer-based flows
+                    # Handle scheduled monitoring (timer-based flows)
                     if flow['trigger_type'] == 'timer':
                         now = time.time()
                         last_run = flow.get('last_run', 0)
                         interval = flow.get('interval', 5) * 60
                         
                         if now - last_run >= interval:
-                            log_notification(f"⏰ Timer trigger: Sending notification for flow '{flow['name']}'")
+                            log_notification(f"⏰ Scheduled monitoring: Running check for flow '{flow['name']}'")
                             # Create data object for condition evaluation
                             timer_data = api_data.copy() if api_data else {}
                             timer_data.update({
@@ -261,16 +261,19 @@ def check_endpoints():
                                 flow['last_value'] = current_value
                                 config_changed = True
                     
-                    # Handle change detection flows
+                    # Handle change detection flows (immediate on change)
                     elif flow['trigger_type'] == 'on_change':
                         if not flow.get('endpoint') or not flow.get('field'):
                             continue
                             
+                        # Initialize last_value if not present
                         if 'last_value' not in flow:
                             flow['last_value'] = current_value
                             config_changed = True
+                            log_notification(f"🔍 Change detection: Initialized baseline for flow '{flow['name']}' with value '{current_value}'")
                             continue
                         
+                        # Only proceed if value actually changed
                         if current_value != flow['last_value']:
                             log_notification(f"🔄 Change detected: Field '{flow['field']}' changed from '{flow['last_value']}' to '{current_value}' in flow '{flow['name']}'")
                             # Create a data object that includes both API data and change information

--- a/static/style.css
+++ b/static/style.css
@@ -2073,3 +2073,61 @@ input[type="color"] {
 @keyframes toast-out {
   to { opacity: 0; transform: translateY(-10px); }
 }
+
+/* Help text styling */
+.help-text {
+    margin-top: 10px;
+    padding: 10px;
+    background-color: #f8f9fa;
+    border-left: 3px solid #007bff;
+    border-radius: 3px;
+}
+
+.help-text small {
+    line-height: 1.4;
+}
+
+/* Flow type badges */
+.flow-type {
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.8em;
+    font-weight: bold;
+}
+
+.flow-type.timer {
+    background-color: #e3f2fd;
+    color: #1976d2;
+}
+
+.flow-type.change {
+    background-color: #e8f5e8;
+    color: #388e3c;
+}
+
+.flow-type.webhook {
+    background-color: #fff3e0;
+    color: #f57c00;
+}
+
+.badge {
+    padding: 3px 8px;
+    border-radius: 3px;
+    font-size: 0.75em;
+    font-weight: bold;
+}
+
+.badge-timer {
+    background-color: #e3f2fd;
+    color: #1976d2;
+}
+
+.badge-change {
+    background-color: #e8f5e8;
+    color: #388e3c;
+}
+
+.badge-webhook {
+    background-color: #fff3e0;
+    color: #f57c00;
+}

--- a/templates/builder.html
+++ b/templates/builder.html
@@ -141,16 +141,30 @@
                             <div class="radio-group">
                                 <label>
                                     <input type="radio" name="trigger_type" value="timer"
-                                           {% if editing_flow and editing_flow.trigger_type == 'timer' or (template_data and template_data.trigger_type == 'timer') %}checked{% endif %}> Timer
+                                           {% if editing_flow and editing_flow.trigger_type == 'timer' or (template_data and template_data.trigger_type == 'timer') %}checked{% endif %}> 
+                                    <strong>Scheduled Monitoring</strong>
+                                    <small>Regular checks at fixed intervals (good for reports, health checks, periodic updates)</small>
                                 </label>
                                 <label>
                                     <input type="radio" name="trigger_type" value="on_change"
-                                           {% if (not editing_flow and not template_data) or (editing_flow and editing_flow.trigger_type == 'on_change') or (template_data and template_data.trigger_type == 'on_change') %}checked{% endif %}> On Change
+                                           {% if (not editing_flow and not template_data) or (editing_flow and editing_flow.trigger_type == 'on_change') or (template_data and template_data.trigger_type == 'on_change') %}checked{% endif %}> 
+                                    <strong>Change Detection</strong>
+                                    <small>Immediate alerts when monitored values change (good for status changes, alerts, events)</small>
                                 </label>
                                 <label id="on-incoming-option" style="display: none;">
                                     <input type="radio" name="trigger_type" value="on_incoming"
-                                           {% if editing_flow and editing_flow.trigger_type == 'on_incoming' or (template_data and template_data.trigger_type == 'on_incoming') %}checked{% endif %}> On Incoming Webhook
+                                           {% if editing_flow and editing_flow.trigger_type == 'on_incoming' or (template_data and template_data.trigger_type == 'on_incoming') %}checked{% endif %}> 
+                                    <strong>Webhook Trigger</strong>
+                                    <small>Responds to incoming webhook calls</small>
                                 </label>
+                            </div>
+                            <div class="help-text">
+                                <small>
+                                    <strong>💡 Which trigger type should I choose?</strong><br>
+                                    • <strong>Scheduled:</strong> Use for regular reports, health checks, or when you want notifications at specific times regardless of data changes<br>
+                                    • <strong>Change Detection:</strong> Use for immediate alerts when something changes (status updates, new data, thresholds crossed)<br>
+                                    • <strong>Webhook:</strong> Use when external systems need to trigger notifications
+                                </small>
                             </div>
                         </div>
                         <div class="form-group" id="timer-options" style="display: none;">
@@ -164,7 +178,7 @@
                                        {% if editing_flow and editing_flow.condition_enabled %}checked{% endif %}> 
                                 Enable Conditional Notifications
                             </label>
-                            <small>Only send notifications when conditions are met</small>
+                            <small>Add extra conditions beyond the trigger type (e.g., only send if value > 100)</small>
                         </div>
                         <div id="condition-config" style="display: none;">
                             <div class="form-group">
@@ -181,9 +195,11 @@
                                     <br>
                                     • <code>result['downloaded_issues'] > 0</code> - Only if downloads exist
                                     <br>
-                                    • <code>value != old_value and value != 'error'</code> - Only on change and not error
-                                    <br>
                                     • <code>data['status'] == 'active'</code> - Only if status is active
+                                    <br>
+                                    • <code>value > old_value</code> - Only if value increased (for scheduled monitoring)
+                                    <br>
+                                    <strong>Note:</strong> Change Detection already filters for <code>value != old_value</code>
                                     <br>
                                     <strong>Operators:</strong> ==, !=, >, <, >=, <=, and, or, not, in, not in
                                 </small>

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,11 +84,11 @@
                                 <p><strong>Category:</strong> {{ flow.category or 'General' }}</p>
                                 <p><strong>Type:</strong> 
                                     {% if flow.trigger_type == 'timer' %}
-                                        Timer (every {{ flow.interval }} minutes)
+                                        <span class="flow-type timer">Scheduled ({{ flow.interval }}m)</span>
                                     {% elif flow.trigger_type == 'on_change' %}
-                                        Change Detection
-                                    {% else %}
-                                        Webhook Trigger
+                                        <span class="flow-type change">Change Detection</span>
+                                    {% elif flow.trigger_type == 'on_incoming' %}
+                                        <span class="flow-type webhook">Webhook</span>
                                     {% endif %}
                                 </p>
                                 <p><strong>Status:</strong> 

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -44,11 +44,11 @@
                         <div class="detail-item">
                             <strong>Trigger:</strong> 
                             {% if template.trigger_type == 'timer' %}
-                                Timer
+                                <span class="badge badge-timer">Scheduled</span>
                             {% elif template.trigger_type == 'on_change' %}
-                                Change Detection
-                            {% else %}
-                                Webhook
+                                <span class="badge badge-change">Change Detection</span>
+                            {% elif template.trigger_type == 'on_incoming' %}
+                                <span class="badge badge-webhook">Webhook</span>
                             {% endif %}
                         </div>
                         


### PR DESCRIPTION
Differentiate 'Timer' and 'On Change' trigger types by renaming them and adding clearer UI explanations.

The original trigger types had overlapping functionality, leading to confusion. This PR renames them to 'Scheduled Monitoring' and 'Change Detection' respectively, and enhances the UI with descriptive text and styling to guide users on their distinct use cases, improving clarity and efficiency.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b172dbd-3c8d-4c2e-9e87-ceb96e1dc7e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b172dbd-3c8d-4c2e-9e87-ceb96e1dc7e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>