### PR TITLE
Use placeholder for default webhook url

### DIFF
--- a/templates/builder.html
+++ b/templates/builder.html
@@ -28,8 +28,9 @@
                         <div class="form-group">
                             <label for="webhook_url">Discord Webhook URL:</label>
                             <input type="url" id="webhook_url" name="webhook_url" 
-                                   value="{{ editing_flow.webhook_url if editing_flow else webhook_url }}" 
-                                   placeholder="https://discord.com/api/webhooks/..." required>
+                                   value="{{ editing_flow.webhook_url if editing_flow else '' }}" 
+                                   placeholder="{{ config.discord_webhook if config.discord_webhook else 'https://discord.com/api/webhooks/...' }}" required>
+                            <small>Leave empty to use the default: {{ config.discord_webhook if config.discord_webhook else 'None configured' }}</small>
                         </div>
                         <div class="form-group">
                             <label for="flow_name">Flow Name:</label>


### PR DESCRIPTION
Update webhook URL field in builder to use a dynamic placeholder and allow default fallback, consistent with other fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-2aa83b7d-44cc-4667-82cd-095e259c9eef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2aa83b7d-44cc-4667-82cd-095e259c9eef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>