### PR TITLE
Fix notification preview saved variables

### DIFF
--- a/endpoints/routes.py
+++ b/endpoints/routes.py
@@ -690,6 +690,10 @@ def init_routes(app):
     def preview_notification():
         """Preview how a notification will look"""
         try:
+            # Load user variables from config
+            config = get_config()
+            user_variables = config.get('user_variables', {})
+            
             # Get form data
             message_template = request.form.get('message_template', '')
             embed_enabled = request.form.get('embed_enabled') == 'true'
@@ -759,7 +763,7 @@ def init_routes(app):
             api_request_body = request.form.get('api_request_body', '')
 
             # Format the message
-            formatted_message = format_message_template(message_template, sample_data)
+            formatted_message = format_message_template(message_template, sample_data, user_variables)
             
             # Create embed preview if enabled
             embed_preview = None
@@ -782,7 +786,7 @@ def init_routes(app):
                     'dynamic_fields': []
                 }
                 
-                embed_preview = create_discord_embed(embed_config, sample_data)
+                embed_preview = create_discord_embed(embed_config, sample_data, user_variables)
             
             return jsonify({
                 'success': True,


### PR DESCRIPTION
Fix notification preview in the builder to correctly display saved variables.

The `preview_notification` endpoint was not loading user variables from the configuration, causing `var:` placeholders to appear as "N/A". This PR ensures user variables are loaded and passed to the message formatting and embed creation functions for accurate previews.

---
<a href="https://cursor.com/background-agent?bcId=bc-84668ad4-9cbe-4ce5-badc-82b176896a61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84668ad4-9cbe-4ce5-badc-82b176896a61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>