### PR TITLE
Update webhook trigger UI and options

### DIFF
--- a/templates/builder.html
+++ b/templates/builder.html
@@ -58,31 +58,7 @@
 
                     <section class="builder-section">
                         <h3>Trigger Settings</h3>
-                        <div class="form-group">
-                            <h4>Webhook Receiver</h4>
-                            <label>
-                                <input type="checkbox" name="accept_webhooks" id="accept_webhooks" value="true"
-                                       {% if editing_flow and editing_flow.accept_webhooks %}checked{% endif %}> 
-                                Accept incoming webhooks
-                            </label>
-                            <div id="require-secret-container" style="display: none; margin-top: 8px;">
-                                <label>
-                                    <input type="checkbox" name="require_webhook_secret" id="require_webhook_secret" value="true"
-                                           {% if editing_flow and editing_flow.webhook_secret %}checked{% endif %}>
-                                    Require secret key for incoming webhooks (X-Secret header)
-                                </label>
-                            </div>
-                            <div class="webhook-info" style="display: none;">
-                                <p>Use this URL to receive webhooks from external services:</p>
-                                <div class="webhook-url">
-                                    <code id="webhook-url-display">/api/webhook/</code>
-                                    <input type="text" id="flow-name-display" 
-                                           value="{{ editing_flow.name if editing_flow else '' }}" readonly>
-                                    <button type="button" onclick="copyWebhookUrl()">Copy</button>
-                                </div>
-                                <small>Configure your external service (Sonarr, Radarr, etc.) to POST JSON data to this URL</small>
-                            </div>
-                        </div>
+
                         <div class="form-group">
                             <label for="endpoint">API Endpoint:</label>
                             <input type="url" id="endpoint" name="endpoint" 
@@ -152,11 +128,11 @@
                                     <strong>Change Detection</strong>
                                     <small>Immediate alerts when monitored values change (good for status changes, alerts, events)</small>
                                 </label>
-                                <label id="on-incoming-option" style="display: none;">
-                                    <input type="radio" name="trigger_type" value="on_incoming"
-                                           {% if editing_flow and editing_flow.trigger_type == 'on_incoming' or (template_data and template_data.trigger_type == 'on_incoming') %}checked{% endif %}> 
-                                    <strong>Webhook Trigger</strong>
-                                    <small>Responds to incoming webhook calls</small>
+                                <label>
+                                    <input type="checkbox" name="accept_webhooks" id="accept_webhooks" value="true"
+                                           {% if editing_flow and editing_flow.accept_webhooks %}checked{% endif %}> 
+                                    <strong>Incoming Webhook</strong>
+                                    <small>Responds to incoming webhook calls from external services</small>
                                 </label>
                             </div>
                             <div class="help-text">
@@ -164,8 +140,27 @@
                                     <strong>💡 Which trigger type should I choose?</strong><br>
                                     • <strong>Scheduled:</strong> Use for regular reports, health checks, or when you want notifications at specific times regardless of data changes<br>
                                     • <strong>Change Detection:</strong> Use for immediate alerts when something changes (status updates, new data, thresholds crossed)<br>
-                                    • <strong>Webhook:</strong> Use when external systems need to trigger notifications
+                                    • <strong>Incoming Webhook:</strong> Use when external systems need to trigger notifications
                                 </small>
+                            </div>
+                        </div>
+                        <div class="form-group" id="webhook-options" style="display: none;">
+                            <div id="require-secret-container" style="margin-bottom: 12px;">
+                                <label>
+                                    <input type="checkbox" name="require_webhook_secret" id="require_webhook_secret" value="true"
+                                           {% if editing_flow and editing_flow.webhook_secret %}checked{% endif %}>
+                                    Require secret key for incoming webhooks (X-Secret header)
+                                </label>
+                            </div>
+                            <div class="webhook-info">
+                                <p>Use this URL to receive webhooks from external services:</p>
+                                <div class="webhook-url">
+                                    <code id="webhook-url-display">/api/webhook/</code>
+                                    <input type="text" id="flow-name-display" 
+                                           value="{{ editing_flow.name if editing_flow else '' }}" readonly>
+                                    <button type="button" onclick="copyWebhookUrl()">Copy</button>
+                                </div>
+                                <small>Configure your external service (Sonarr, Radarr, etc.) to POST JSON data to this URL</small>
                             </div>
                         </div>
                         <div class="form-group" id="timer-options" style="display: none;">
@@ -431,11 +426,12 @@
                             Timer (every {{ flow.interval }} minutes)
                         {% elif flow.trigger_type == 'on_change' %}
                             On Change ({{ flow.field }} on {{ flow.endpoint }})
-                        {% else %}
-                            On Incoming Webhook
+                        {% endif %}
+                        {% if flow.accept_webhooks %}
+                            {% if flow.trigger_type == 'timer' or flow.trigger_type == 'on_change' %} + {% endif %}Incoming Webhook
                         {% endif %}
                     </p>
-                    {% if flow.accept_webhooks or flow.trigger_type == 'on_incoming' %}
+                    {% if flow.accept_webhooks %}
                     <p><strong>Webhook URL:</strong> /api/webhook/{{ flow.name }}</p>
                     {% if flow.webhook_secret %}
                     <p><strong>Webhook Secret:</strong> {{ flow.webhook_secret }}</p>
@@ -488,11 +484,10 @@
             // Form Configuration Elements
             const flowNameInput = document.getElementById('flow_name');
             const webhookDisplay = document.getElementById('flow-name-display');
-            const webhookSection = document.querySelector('.webhook-info');
+            const webhookOptions = document.getElementById('webhook-options');
             const acceptWebhooksCheckbox = document.getElementById('accept_webhooks');
             const requireSecretContainer = document.getElementById('require-secret-container');
             const requireSecretCheckbox = document.getElementById('require_webhook_secret');
-            const onIncomingOption = document.getElementById('on-incoming-option');
             const timerOptions = document.getElementById('timer-options');
             const changeOptions = document.getElementById('on-change-options');
             const triggerTypeRadios = document.querySelectorAll('input[name="trigger_type"]');
@@ -518,18 +513,10 @@
             if (acceptWebhooksCheckbox) {
                 acceptWebhooksCheckbox.addEventListener('change', function() {
                     updateWebhookVisibility();
-                    updateTriggerOptions();
                 });
             }
 
-            if (requireSecretContainer && requireSecretCheckbox) {
-                requireSecretContainer.style.display = acceptWebhooksCheckbox?.checked ? 'block' : 'none';
-                requireSecretCheckbox.addEventListener('change', function() {
-                    // This checkbox is not directly tied to a form field,
-                    // so we don't need to append it to FormData.
-                    // It's just for UI feedback.
-                });
-            }
+
         
             // Update options when trigger type changes
             triggerTypeRadios.forEach(radio => {
@@ -632,11 +619,8 @@
         
             // Helper functions
             function updateWebhookVisibility() {
-                if (acceptWebhooksCheckbox && webhookSection) {
-                    webhookSection.style.display = acceptWebhooksCheckbox.checked ? 'block' : 'none';
-                }
-                if (requireSecretContainer && requireSecretCheckbox) {
-                    requireSecretContainer.style.display = acceptWebhooksCheckbox?.checked ? 'block' : 'none';
+                if (acceptWebhooksCheckbox && webhookOptions) {
+                    webhookOptions.style.display = acceptWebhooksCheckbox.checked ? 'block' : 'none';
                 }
             }
             
@@ -664,11 +648,6 @@
         
             function updateTriggerOptions() {
                 const selectedTrigger = document.querySelector('input[name="trigger_type"]:checked')?.value || 'on_change';
-                
-                // Show/hide On Incoming option
-                if (onIncomingOption) {
-                    onIncomingOption.style.display = acceptWebhooksCheckbox?.checked ? 'block' : 'none';
-                }
         
                 // Show/hide Timer options
                 if (timerOptions) {


### PR DESCRIPTION
Move and rebrand the "Accept incoming webhooks" option to integrate it directly with trigger types for improved UX and flexibility.

The previous "Accept incoming webhooks" was a separate checkbox that also controlled the visibility of a "Webhook Trigger" radio button. This PR streamlines the interface by making "Incoming Webhook" a checkbox option alongside other trigger types, allowing it to be combined with other triggers (e.g., Scheduled + Incoming Webhook) and simplifying the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a08872a-41d3-446e-a2a8-20c6939c4ba5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a08872a-41d3-446e-a2a8-20c6939c4ba5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>