### PR TITLE
Fix broken variable display

### DIFF
--- a/functions/utils.py
+++ b/functions/utils.py
@@ -338,13 +338,13 @@ def format_message_template(template, data, user_variables=None):
             log_notification(f"Calculation replacement error: {str(e)}")
             return f"CALC_ERROR"
     
-    # First replace all [calculation] patterns using regex
-    calc_pattern = r'\[([^\]]+)\]'
-    result = re.sub(calc_pattern, replace_calculation, template)
-    
-    # Then replace all {variable} patterns
+    # First replace all {variable} patterns
     pattern = r'\{([^}]+)\}'
-    result = re.sub(pattern, replace_template_var, result)
+    result = re.sub(pattern, replace_template_var, template)
+    
+    # Then replace all standalone [calculation] patterns (not inside variables)
+    calc_pattern = r'\[([^\]]+)\]'
+    result = re.sub(calc_pattern, replace_calculation, result)
     
     return result
 


### PR DESCRIPTION
Reorder regex processing in `format_message_template` to fix variable substitution.

The previous order of regex application caused calculation patterns to incorrectly transform bracket notation within variables (e.g., `{result['0']['web_title']}`), leading to "N/A" values. This PR ensures variables are processed before standalone calculations.

---
<a href="https://cursor.com/background-agent?bcId=bc-19cd2deb-18fc-4210-8f5a-ae7a8d378b35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19cd2deb-18fc-4210-8f5a-ae7a8d378b35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>