### PR TITLE
Fix notification total sent counter

### DIFF
--- a/functions/config.py
+++ b/functions/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import fcntl
 from datetime import datetime
 
 # Configuration files
@@ -39,42 +40,92 @@ def get_config():
     return config
 
 def save_config(config):
-    """Save configuration to file with proper serialization
+    """Save configuration to file with proper serialization.
     
-    Additionally preserves monotonic counters that may be updated concurrently
-    by merging with the on-disk value before writing (e.g., 'total_notifications_sent').
+    Guarantees that 'total_notifications_sent' is monotonic and resilient to
+    concurrent saves by performing a locked read-modify-write. Also sanitizes
+    non-numeric values to avoid TypeError during comparisons.
     """
-    # Create a copy of config to avoid modifying the original
-    config_copy = config.copy()
     
-    # Convert any last_data that might be complex objects to JSON strings
+    def to_non_negative_int(value, default=0):
+        try:
+            if isinstance(value, bool):
+                # Avoid True -> 1 surprises
+                return default
+            if isinstance(value, int):
+                return max(0, value)
+            if isinstance(value, float):
+                return max(0, int(value))
+            if isinstance(value, str):
+                v = value.strip()
+                # Try int directly; fallback to float then int
+                try:
+                    return max(0, int(v))
+                except Exception:
+                    try:
+                        return max(0, int(float(v)))
+                    except Exception:
+                        return default
+            return default
+        except Exception:
+            return default
+    
+    # Prepare a serializable copy first (convert any complex last_data to string)
+    config_copy = config.copy()
     for flow in config_copy.get('notification_flows', []):
         if 'last_data' in flow and not isinstance(flow['last_data'], str):
-            flow['last_data'] = json.dumps(flow['last_data'])
+            try:
+                flow['last_data'] = json.dumps(flow['last_data'])
+            except Exception:
+                # If it cannot be serialized, drop it rather than breaking saves
+                flow['last_data'] = ""
     
-    # Preserve monotonic counters from existing on-disk config to avoid clobbering
-    try:
-        with open(CONFIG_FILE, 'r') as f:
-            existing_cfg = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        existing_cfg = {}
+    # Normalize incoming counter value
+    incoming_total = to_non_negative_int(config_copy.get('total_notifications_sent', 0), 0)
     
-    # Ensure we do not decrease total_notifications_sent due to concurrent saves
-    existing_total = existing_cfg.get('total_notifications_sent', 0)
-    incoming_total = config_copy.get('total_notifications_sent', existing_total)
-    
-    # Also ensure it's at least the count of current notification log entries
+    # Also bound by current sent notifications log length
     try:
         with open('data/sent_notifications.json', 'r') as f:
             sent_logs = json.load(f)
-            current_log_total = len(sent_logs) if isinstance(sent_logs, list) else 0
+            current_log_total = to_non_negative_int(len(sent_logs) if isinstance(sent_logs, list) else 0, 0)
     except (FileNotFoundError, json.JSONDecodeError):
         current_log_total = 0
     
-    config_copy['total_notifications_sent'] = max(existing_total, incoming_total, current_log_total)
+    # Ensure data directory exists
+    os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
     
-    with open(CONFIG_FILE, 'w') as f:
-        json.dump(config_copy, f, indent=4)
+    # Locked read-modify-write to avoid TOCTOU
+    fd = os.open(CONFIG_FILE, os.O_RDWR | os.O_CREAT)
+    try:
+        with os.fdopen(fd, 'r+') as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                try:
+                    f.seek(0)
+                    existing_cfg = json.load(f)
+                    if not isinstance(existing_cfg, dict):
+                        existing_cfg = {}
+                except Exception:
+                    existing_cfg = {}
+                
+                existing_total = to_non_negative_int(existing_cfg.get('total_notifications_sent', 0), 0)
+                final_total = max(existing_total, incoming_total, current_log_total)
+                config_copy['total_notifications_sent'] = final_total
+                
+                # Write back atomically under the same lock
+                f.seek(0)
+                json.dump(config_copy, f, indent=4)
+                f.truncate()
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+    except Exception:
+        # If something goes wrong with locked write, fall back to a best-effort write
+        # using atomic replace to avoid partial writes.
+        config_copy['total_notifications_sent'] = max(incoming_total, current_log_total)
+        tmp_path = CONFIG_FILE + '.tmp'
+        with open(tmp_path, 'w') as tf:
+            json.dump(config_copy, tf, indent=4)
+        os.replace(tmp_path, CONFIG_FILE)
 
 def get_logs():
     """Get logs from the separate log file"""


### PR DESCRIPTION
Ensure `notifications.total_sent` is monotonically increasing by merging its value during config saves.

The `total_notifications_sent` counter was not increasing because concurrent `save_config()` calls would clobber the latest increment with an older in-memory copy of the config. This fix ensures the counter always takes the maximum of the incoming, on-disk, and `sent_notifications.json` count values.

---
<a href="https://cursor.com/background-agent?bcId=bc-3232848f-77e1-46fa-9711-30a94092e1e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3232848f-77e1-46fa-9711-30a94092e1e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

