### PR TITLE
Publish development branch as separate Docker package

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -20,15 +21,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Determine image name
-      id: image
-      run: |
-        if [[ "${GITHUB_REF}" == "refs/heads/development" ]] || [[ "${GITHUB_BASE_REF}" == "development" ]]; then
-          echo "name=${GITHUB_REPOSITORY}-development" >> "$GITHUB_OUTPUT"
-        else
-          echo "name=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -40,7 +32,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
           type=ref,event=tag

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,13 +2,12 @@ name: Build and release Docker image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -21,6 +20,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Determine image name
+      id: image
+      run: |
+        if [[ "${GITHUB_REF}" == "refs/heads/development" ]] || [[ "${GITHUB_BASE_REF}" == "development" ]]; then
+          echo "name=${GITHUB_REPOSITORY}-development" >> "$GITHUB_OUTPUT"
+        else
+          echo "name=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -32,13 +40,13 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
         tags: |
-          type=schedule
           type=ref,event=branch
           type=ref,event=tag
           type=ref,event=pr
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          type=raw,value=development,enable=${{ github.ref == 'refs/heads/development' }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ docker run -p 5000:5000 -v $(pwd)/data:/app/data ghcr.io/leemotheyer/turtificati
 
 **Development (development branch)**
 
-Published as a separate package so stable releases are not overwritten:
+Same package, separate tag — stable `latest` is not overwritten:
 
 ```bash
-docker pull ghcr.io/leemotheyer/turtifications-development:development
-docker run -p 5000:5000 -v $(pwd)/data:/app/data ghcr.io/leemotheyer/turtifications-development:development
+docker pull ghcr.io/leemotheyer/turtifications:development
+docker run -p 5000:5000 -v $(pwd)/data:/app/data ghcr.io/leemotheyer/turtifications:development
 ```
 
 **Build locally**

--- a/README.md
+++ b/README.md
@@ -88,8 +88,26 @@ gunicorn -w 4 -b 0.0.0.0:5000 app:app
 ```
 
 ### Docker
+
+**Stable (main branch)**
+
 ```bash
-# Build and run with Docker
+docker pull ghcr.io/leemotheyer/turtifications:latest
+docker run -p 5000:5000 -v $(pwd)/data:/app/data ghcr.io/leemotheyer/turtifications:latest
+```
+
+**Development (development branch)**
+
+Published as a separate package so stable releases are not overwritten:
+
+```bash
+docker pull ghcr.io/leemotheyer/turtifications-development:development
+docker run -p 5000:5000 -v $(pwd)/data:/app/data ghcr.io/leemotheyer/turtifications-development:development
+```
+
+**Build locally**
+
+```bash
 docker build -t turtifications .
 docker run -p 5000:5000 -v $(pwd)/data:/app/data turtifications
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publishes Docker images from both `main` and `development` to a single GHCR package with separate tags, so stable `latest` is never overwritten by development builds.

## Tags

| Branch | Image |
|--------|-------|
| `main` | `ghcr.io/leemotheyer/turtifications:latest` |
| `development` | `ghcr.io/leemotheyer/turtifications:development` |

## Usage

**Stable (main):**
```bash
docker pull ghcr.io/leemotheyer/turtifications:latest
```

**Development:**
```bash
docker pull ghcr.io/leemotheyer/turtifications:development
```

After this is merged into `development`, the next push to that branch will publish the `development` tag automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-056af2a4-aad3-4a00-b814-fbe5ebf1c925?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-056af2a4-aad3-4a00-b814-fbe5ebf1c925&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

