### PR TITLE
Fix mobile burger menu hidden behind page header

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -208,11 +208,10 @@ small {
 /* --------------------------------------------------------------------------
    3. Header & Navigation
    -------------------------------------------------------------------------- */
-header,
 .app-header {
     position: sticky;
     top: 0;
-    z-index: 200;
+    z-index: 300;
     flex-shrink: 0;
     min-height: var(--header-height);
     border-bottom: 1px solid var(--border);
@@ -233,7 +232,6 @@ header,
     min-height: var(--header-height);
 }
 
-header h1,
 .brand {
     display: flex;
     align-items: center;
@@ -243,6 +241,7 @@ header h1,
     font-weight: 700;
     color: var(--text-primary);
     letter-spacing: -0.02em;
+    text-decoration: none;
 }
 
 .brand-mark {
@@ -264,6 +263,8 @@ header h1,
 }
 
 .mobile-menu-toggle {
+    position: relative;
+    z-index: 310;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -292,6 +293,7 @@ nav {
     top: var(--header-height);
     left: 0;
     right: 0;
+    z-index: 290;
     max-height: calc(100vh - var(--header-height));
     overflow-y: auto;
     padding: 0.75rem;
@@ -342,7 +344,7 @@ nav a.active,
 .nav-overlay {
     position: fixed;
     inset: 0;
-    z-index: 150;
+    z-index: 280;
     background: var(--bg-overlay);
     opacity: 0;
     visibility: hidden;
@@ -360,6 +362,8 @@ nav a.active,
    4. Page Header & Onboarding (new UX)
    -------------------------------------------------------------------------- */
 .page-header {
+    position: relative;
+    z-index: 1;
     margin-bottom: 1.5rem;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, opening the burger menu on the dashboard (and other pages) left the page title header covering the navigation links, making the menu unusable.

## Cause

The CSS rule `header, .app-header { position: sticky; z-index: 200; }` applied to **all** `<header>` elements — including the in-page `<header class="page-header">` on the dashboard. That page header stuck to the top of the viewport and sat on top of the mobile nav.

## Fix

- Scope sticky positioning to `.app-header` only
- Scope brand/title flex styles to `.brand` only (not all `header h1`)
- Set explicit z-index layers: app header (300), menu toggle (310), nav (290), overlay (280)
- Keep `.page-header` as normal document flow

## Testing

- Verified no bare `header` selectors remain that apply sticky positioning
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec5c4da1-246d-447b-85b6-b516b36a1fc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec5c4da1-246d-447b-85b6-b516b36a1fc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

