### PR TITLE
Top 10 improvements: bugs, API CRUD, monitor, builder fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main", "development" ]
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run tests
+        run: python -m pytest test/ -q --tb=short

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,7 @@ VOLUME ["/app/data"]
 EXPOSE 5000
 
 # Run the application
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5000/api/health', timeout=4)"
+
 CMD ["python", "app.py"] 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ curl -X POST http://localhost:5000/api/test \
   -d '{"message": "Hello from API!"}'
 ```
 
-Visit `http://localhost:5000/api/docs` for complete API documentation.
+Visit `http://localhost:5000/api/endpoints` for the API reference.
+
+Optional: set `API_KEY` in the environment to require the `X-API-Key` header on mutating API endpoints (`POST/PUT/DELETE /api/flows`, `POST /api/test`).
 
 ## 🚀 Deployment
 

--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 from flask import Flask
-import secrets
 import os
+import secrets
+import threading
 from threading import Thread
-from functions.config import initialize_files
+from functions.config import initialize_files, CONFIG_FILE
 from functions.version import initialize_version
 from endpoints.routes import init_routes
 from endpoints.api import init_api_routes
@@ -10,7 +11,20 @@ from functions.notifications import check_endpoints
 
 # Initialize Flask app
 app = Flask(__name__)
-app.secret_key = secrets.token_hex(16)  # Generate a random secret key
+
+# Stable secret key for sessions (env override or persisted file)
+_secret_key = os.environ.get('SECRET_KEY', '').strip()
+if not _secret_key:
+    secret_file = os.path.join(os.path.dirname(CONFIG_FILE), '.secret_key')
+    if os.path.exists(secret_file):
+        with open(secret_file, 'r') as f:
+            _secret_key = f.read().strip()
+    else:
+        _secret_key = secrets.token_hex(32)
+        os.makedirs(os.path.dirname(secret_file) or '.', exist_ok=True)
+        with open(secret_file, 'w') as f:
+            f.write(_secret_key)
+app.secret_key = _secret_key
 
 # Initialize configuration files
 initialize_files()
@@ -24,14 +38,31 @@ init_routes(app)
 # Initialize API routes
 init_api_routes(app)
 
-if __name__ == '__main__':
-    # Use environment variable for debug mode, default to False for production
+_monitor_thread = None
+_monitor_lock = threading.Lock()
+
+
+def start_monitor_thread():
+    """Start background endpoint monitoring once per process."""
+    global _monitor_thread
+
+    if os.environ.get('DISABLE_MONITOR', '').lower() in ('1', 'true', 'yes'):
+        return
+
+    # Avoid double-start under Flask debug reloader parent process
     debug_mode = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
-    
-    # Only start the thread in the main process (after reloader in debug mode)
-    if os.environ.get('WERKZEUG_RUN_MAIN') == 'true' or not debug_mode:
-        monitor_thread = Thread(target=check_endpoints)
-        monitor_thread.daemon = True
-        monitor_thread.start()
-    
+    if debug_mode and os.environ.get('WERKZEUG_RUN_MAIN') != 'true':
+        return
+
+    with _monitor_lock:
+        if _monitor_thread and _monitor_thread.is_alive():
+            return
+        _monitor_thread = Thread(target=check_endpoints, daemon=True, name='endpoint-monitor')
+        _monitor_thread.start()
+
+
+start_monitor_thread()
+
+if __name__ == '__main__':
+    debug_mode = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
     app.run(debug=debug_mode, host='0.0.0.0')

--- a/endpoints/api.py
+++ b/endpoints/api.py
@@ -4,13 +4,31 @@ API endpoints for the notification organizer app
 
 from flask import jsonify, request
 from datetime import datetime, timedelta
-from functions.config import get_config, get_logs, get_log_stats
+from functions.config import get_config, save_config, get_logs, get_log_stats
 from functions.flow_stats import get_flow_statistics, get_recent_flow_activity
 from functions.notifications import send_discord_notification
 from functions.utils import get_notification_logs
 from functions.version import get_version, get_version_info
+from functions.auth import require_api_key
+from functions.form_parsers import build_flow_from_json
+from functions.embed_utils import validate_embed_config
 import json
-import sys
+
+
+def _sanitize_flow(flow):
+    """Return a copy of a flow without sensitive fields."""
+    safe_flow = flow.copy()
+    safe_flow.pop('webhook_url', None)
+    safe_flow.pop('webhook_secret', None)
+    return safe_flow
+
+
+def _find_flow_index(flows, flow_name):
+    for index, flow in enumerate(flows):
+        if flow.get('name') == flow_name:
+            return index
+    return None
+
 
 def init_api_routes(app):
     """Initialize API routes"""
@@ -35,20 +53,109 @@ def init_api_routes(app):
         """Get all notification flows"""
         config = get_config()
         flows = config.get('notification_flows', [])
-        
-        # Clean up sensitive data
-        safe_flows = []
-        for flow in flows:
-            safe_flow = flow.copy()
-            # Remove webhook URLs for security
-            safe_flow.pop('webhook_url', None)
-            safe_flow.pop('webhook_secret', None)
-            safe_flows.append(safe_flow)
+        safe_flows = [_sanitize_flow(flow) for flow in flows]
         
         return jsonify({
             'flows': safe_flows,
             'count': len(safe_flows)
         })
+    
+    @app.route('/api/flows', methods=['POST'])
+    @require_api_key
+    def api_create_flow():
+        """Create a new notification flow"""
+        try:
+            data = request.get_json(force=True, silent=False)
+            if not data:
+                return jsonify({'error': 'JSON body required'}), 400
+
+            flow = build_flow_from_json(data)
+            embed_config = flow.get('embed_config', {})
+            if embed_config.get('enabled'):
+                errors = validate_embed_config(embed_config)
+                if errors:
+                    return jsonify({'error': '; '.join(errors)}), 400
+
+            config = get_config()
+            flows = config.setdefault('notification_flows', [])
+
+            if _find_flow_index(flows, flow['name']) is not None:
+                return jsonify({'error': 'Flow already exists'}), 409
+
+            flows.append(flow)
+            save_config(config)
+            return jsonify({'success': True, 'flow': _sanitize_flow(flow)}), 201
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+
+    @app.route('/api/flows/<flow_name>', methods=['PUT'])
+    @require_api_key
+    def api_update_flow(flow_name):
+        """Update an existing notification flow"""
+        try:
+            data = request.get_json(force=True, silent=False)
+            if not data:
+                return jsonify({'error': 'JSON body required'}), 400
+
+            config = get_config()
+            flows = config.get('notification_flows', [])
+            index = _find_flow_index(flows, flow_name)
+            if index is None:
+                return jsonify({'error': 'Flow not found'}), 404
+
+            if data.get('name') and data['name'] != flow_name:
+                if _find_flow_index(flows, data['name']) is not None:
+                    return jsonify({'error': 'Target flow name already exists'}), 409
+
+            flow = build_flow_from_json(data, existing_flow=flows[index])
+            embed_config = flow.get('embed_config', {})
+            if embed_config.get('enabled'):
+                errors = validate_embed_config(embed_config)
+                if errors:
+                    return jsonify({'error': '; '.join(errors)}), 400
+
+            flows[index] = flow
+            save_config(config)
+            return jsonify({'success': True, 'flow': _sanitize_flow(flow)})
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+
+    @app.route('/api/flows/<flow_name>', methods=['DELETE'])
+    @require_api_key
+    def api_delete_flow(flow_name):
+        """Delete a notification flow"""
+        config = get_config()
+        flows = config.get('notification_flows', [])
+        index = _find_flow_index(flows, flow_name)
+        if index is None:
+            return jsonify({'error': 'Flow not found'}), 404
+
+        removed = flows.pop(index)
+        save_config(config)
+        return jsonify({'success': True, 'deleted': _sanitize_flow(removed)})
+
+    @app.route('/api/flows/<flow_name>/toggle', methods=['POST'])
+    @require_api_key
+    def api_toggle_flow(flow_name):
+        """Enable or disable a notification flow"""
+        data = request.get_json(silent=True) or {}
+        active = data.get('active')
+        if active is None:
+            return jsonify({'error': 'active (boolean) is required'}), 400
+
+        config = get_config()
+        flows = config.get('notification_flows', [])
+        index = _find_flow_index(flows, flow_name)
+        if index is None:
+            return jsonify({'error': 'Flow not found'}), 404
+
+        flows[index]['active'] = bool(active)
+        save_config(config)
+        return jsonify({'success': True, 'flow': _sanitize_flow(flows[index])})
     
     @app.route('/api/flows/active')
     def api_active_flows():
@@ -56,14 +163,7 @@ def init_api_routes(app):
         config = get_config()
         flows = config.get('notification_flows', [])
         active_flows = [flow for flow in flows if flow.get('active', False)]
-        
-        # Clean up sensitive data
-        safe_flows = []
-        for flow in active_flows:
-            safe_flow = flow.copy()
-            safe_flow.pop('webhook_url', None)
-            safe_flow.pop('webhook_secret', None)
-            safe_flows.append(safe_flow)
+        safe_flows = [_sanitize_flow(flow) for flow in active_flows]
         
         return jsonify({
             'flows': safe_flows,
@@ -80,12 +180,7 @@ def init_api_routes(app):
         if not flow:
             return jsonify({'error': 'Flow not found'}), 404
         
-        # Clean up sensitive data
-        safe_flow = flow.copy()
-        safe_flow.pop('webhook_url', None)
-        safe_flow.pop('webhook_secret', None)
-        
-        return jsonify(safe_flow)
+        return jsonify(_sanitize_flow(flow))
     
     @app.route('/api/statistics')
     def api_statistics():
@@ -94,29 +189,22 @@ def init_api_routes(app):
         flows = config.get('notification_flows', [])
         logs = get_logs()
         
-        # Basic flow statistics
         active_flows = [flow for flow in flows if flow.get('active', False)]
         timer_flows = [flow for flow in flows if flow.get('trigger_type') == 'timer']
         change_flows = [flow for flow in flows if flow.get('trigger_type') == 'on_change']
-        webhook_flows = [flow for flow in flows if flow.get('trigger_type') == 'on_incoming']
+        webhook_flows = [flow for flow in flows if flow.get('trigger_type') in ('webhook', 'on_incoming')]
         
-        # Get detailed flow statistics
         flow_stats = get_flow_statistics()
-        
-        # Recent activity (last 24 hours)
         recent_activity = get_recent_flow_activity(24)
         
-        # Log statistics
         total_logs = len(logs)
         recent_logs = len([log for log in logs if 
                           datetime.now() - datetime.strptime(log['timestamp'], '%Y-%m-%d %H:%M:%S') < timedelta(hours=24)])
         
-        # Notification statistics
         notification_logs = get_notification_logs()
         total_notifications_in_log = len(notification_logs)
         total_notifications_sent = config.get('total_notifications_sent', 0)
         
-        # Calculate notifications in last 24 hours
         now = datetime.now()
         notifications_24h = 0
         for notification in notification_logs:
@@ -156,7 +244,7 @@ def init_api_routes(app):
     def api_logs():
         """Get recent logs"""
         limit = request.args.get('limit', 50, type=int)
-        limit = min(limit, 1000)  # Cap at 1000 logs
+        limit = min(limit, 1000)
         
         logs = get_logs()
         recent_logs = list(reversed(logs))[:limit]
@@ -171,7 +259,6 @@ def init_api_routes(app):
     def api_log_stats():
         """Get log statistics"""
         stats = get_log_stats()
-        
         return jsonify(stats)
     
     @app.route('/api/health')
@@ -179,7 +266,6 @@ def init_api_routes(app):
         """Health check endpoint"""
         config = get_config()
         
-        # Basic health checks
         health_status = {
             'status': 'healthy',
             'timestamp': datetime.now().isoformat(),
@@ -190,7 +276,6 @@ def init_api_routes(app):
             }
         }
         
-        # Check if any critical issues
         if not config.get('discord_webhook'):
             health_status['status'] = 'warning'
             health_status['message'] = 'Discord webhook not configured'
@@ -198,54 +283,47 @@ def init_api_routes(app):
         return jsonify(health_status)
     
     @app.route('/api/test', methods=['POST'])
+    @require_api_key
     def api_test_notification():
         """Send a test notification via API"""
         try:
-            # Safely parse JSON data with validation
             data = request.get_json(force=True, silent=False, cache=False)
             
-            # Validate that we received valid JSON data
             if not data:
                 return jsonify({'error': 'No JSON data provided or invalid JSON format'}), 400
             
-            # Validate data size to prevent DoS attacks
             import sys
             data_size = sys.getsizeof(str(data))
-            max_size = 1024 * 512  # 512KB limit for test notifications
+            max_size = 1024 * 512
             if data_size > max_size:
                 return jsonify({'error': f'Request data too large ({data_size} bytes, max {max_size})'}), 413
             
-            # Extract and validate message
             message = data.get('message', 'Test notification from API')
             if not isinstance(message, str):
                 return jsonify({'error': 'Message must be a string'}), 400
             
-            # Validate message length
-            if len(message) > 2000:  # Discord message limit
+            if len(message) > 2000:
                 return jsonify({'error': 'Message too long (max 2000 characters)'}), 400
             
             webhook_url = data.get('webhook_url')
             
             if not webhook_url:
-                # Use default webhook from config
                 config = get_config()
                 webhook_url = config.get('discord_webhook')
                 if not webhook_url:
                     return jsonify({'error': 'No webhook URL provided and no default configured'}), 400
             
-            # Validate webhook URL format
             if not isinstance(webhook_url, str) or not webhook_url.startswith('https://'):
                 return jsonify({'error': 'Invalid webhook URL format'}), 400
             
-            # Create a simple test flow
             test_flow = {
                 'webhook_url': webhook_url,
                 'webhook_name': data.get('webhook_name', ''),
                 'webhook_avatar': data.get('webhook_avatar', ''),
-                'message_template': message
+                'message_template': message,
+                'embed_config': data.get('embed_config', {}),
             }
             
-            # Send notification
             if send_discord_notification(message, test_flow):
                 return jsonify({
                     'success': True,
@@ -257,7 +335,7 @@ def init_api_routes(app):
                     'error': 'Failed to send notification'
                 }), 500
                 
-        except ValueError as json_error:
+        except ValueError:
             return jsonify({
                 'success': False,
                 'error': 'Invalid JSON format'
@@ -275,14 +353,19 @@ def init_api_routes(app):
             'endpoints': {
                 'GET /api/status': 'Get overall app status',
                 'GET /api/flows': 'Get all notification flows',
+                'POST /api/flows': 'Create a notification flow (API key if configured)',
+                'PUT /api/flows/<name>': 'Update a notification flow (API key if configured)',
+                'DELETE /api/flows/<name>': 'Delete a notification flow (API key if configured)',
+                'POST /api/flows/<name>/toggle': 'Enable/disable a flow (API key if configured)',
                 'GET /api/flows/active': 'Get only active flows',
                 'GET /api/flows/<name>': 'Get specific flow details',
                 'GET /api/statistics': 'Get comprehensive statistics',
                 'GET /api/logs': 'Get recent logs (optional: ?limit=50)',
                 'GET /api/logs/stats': 'Get log statistics',
                 'GET /api/health': 'Health check endpoint',
-                'POST /api/test': 'Send test notification',
+                'POST /api/test': 'Send test notification (API key if configured)',
                 'POST /api/webhook/<flow_name>': 'Webhook endpoint for flows'
             },
+            'auth': 'Set API_KEY environment variable to require X-API-Key header on mutating endpoints',
             'timestamp': datetime.now().isoformat()
-        }) 
+        })

--- a/endpoints/routes.py
+++ b/endpoints/routes.py
@@ -3,11 +3,13 @@ import secrets
 import requests
 import json
 import io
+import sys
 from datetime import datetime
 from functions.config import get_config, save_config, get_logs, clear_logs, get_log_stats
 from functions.utils import log_notification, get_notification_logs, format_message_template
 from functions.notifications import send_discord_notification, make_api_request
 from functions.embed_utils import validate_embed_config, create_discord_embed
+from functions.form_parsers import build_flow_from_form, parse_embed_config_from_form
 from functions.flow_templates import FLOW_TEMPLATES, get_template_categories, get_templates_by_category, get_template
 from functions.flow_stats import get_flow_statistics, get_flow_success_rate, get_recent_flow_activity, export_flow_config, import_flow_config, duplicate_flow
 from functions.version import get_version, get_version_info
@@ -219,96 +221,14 @@ def init_routes(app):
                     # No additional validation needed for webhook triggers
                     pass
 
-                # Parse embed configuration
-                embed_config = {}
-                if request.form.get('embed_enabled') == 'true':
-                    color_mode = request.form.get('embed_color_mode', 'static')
-                    embed_config = {
-                        'enabled': True,
-                        'title': request.form.get('embed_title', ''),
-                        'description': request.form.get('embed_description', ''),
-                        'url': request.form.get('embed_url', ''),
-                        'color_mode': color_mode,
-                        'timestamp': request.form.get('embed_timestamp', 'true') == 'true',
-                        'footer_text': request.form.get('embed_footer_text', ''),
-                        'footer_icon': request.form.get('embed_footer_icon', ''),
-                        'author_name': request.form.get('embed_author_name', ''),
-                        'author_icon': request.form.get('embed_author_icon', ''),
-                        'author_url': request.form.get('embed_author_url', ''),
-                        'thumbnail_url': request.form.get('embed_thumbnail_url', ''),
-                        'image_url': request.form.get('embed_image_url', ''),
-                        'fields': [],
-                        'dynamic_fields': []
-                    }
-                    if color_mode == 'static':
-                        embed_config['color'] = request.form.get('embed_color', '')
-                    elif color_mode == 'if':
-                        embed_config['color_monitor'] = request.form.get('embed_color_monitor', '')
-                        tests = request.form.getlist('embed_color_if_test[]')
-                        colors = request.form.getlist('embed_color_if_color[]')
-                        rules = []
-                        for t, c in zip(tests, colors):
-                            if t and c:
-                                rules.append({'test': t, 'color': c})
-                        embed_config['color_rules'] = rules
-                    elif color_mode == 'gradient':
-                        embed_config['color_monitor'] = request.form.get('embed_color_monitor', '')
-                        embed_config['gradient'] = {
-                            'start_value': request.form.get('embed_gradient_start_value', ''),
-                            'start_color': request.form.get('embed_gradient_start_color', '#00ff00'),
-                            'end_value': request.form.get('embed_gradient_end_value', ''),
-                            'end_color': request.form.get('embed_gradient_end_color', '#ff0000'),
-                        }
-                    
+                updated_flow = build_flow_from_form(request.form, editing_flow)
 
-                
-                # Parse advanced API settings
-                api_headers = []
-                header_keys = request.form.getlist('header_key[]')
-                header_values = request.form.getlist('header_value[]')
-                for k, v in zip(header_keys, header_values):
-                    if k:
-                        api_headers.append({'key': k, 'value': v})
-                api_request_body = request.form.get('api_request_body', '')
-
-                updated_flow = {
-                    'name': request.form['flow_name'],
-                    'trigger_type': trigger_type,
-                    'webhook_url': webhook_url,  # Store empty string if not provided, will use default
-                    'webhook_name': request.form.get('webhook_name', '').strip(),  # Allow empty
-                    'webhook_avatar': request.form.get('webhook_avatar', '').strip(),  # Allow empty
-                    'message_template': request.form.get('message_template', ''),
-                    'active': request.form.get('active', 'false') == 'true',
-                    'endpoint': request.form.get('endpoint', ''),
-                    'field': request.form.get('field', ''),
-                    'interval': int(request.form.get('interval', 5)) if trigger_type == 'timer' else None,
-                    'accept_webhooks': accept_webhooks,
-                    'embed_config': embed_config,
-                    'category': request.form.get('category', 'General'),
-                    'condition_enabled': request.form.get('condition_enabled', 'false') == 'true',
-                    'condition': request.form.get('condition', ''),
-                    'api_headers': api_headers,
-                    'api_request_body': api_request_body,
-                }
-                
-                # Handle webhook_secret logic
-                if accept_webhooks and require_webhook_secret:
-                    if editing_flow and editing_flow.get('webhook_secret'):
-                        updated_flow['webhook_secret'] = editing_flow['webhook_secret']
-                    else:
-                        updated_flow['webhook_secret'] = secrets.token_urlsafe(16)
-                # If not required, remove any existing secret
-                elif 'webhook_secret' in updated_flow:
-                    del updated_flow['webhook_secret']
-                
-                # Preserve existing tracking data if editing
-                if editing_flow:
-                    if 'last_value' in editing_flow:
-                        updated_flow['last_value'] = editing_flow['last_value']
-                    if 'last_run' in editing_flow:
-                        updated_flow['last_run'] = editing_flow['last_run']
-                    if 'last_data' in editing_flow:
-                        updated_flow['last_data'] = editing_flow['last_data']
+                embed_config = updated_flow.get('embed_config', {})
+                if embed_config.get('enabled'):
+                    errors = validate_embed_config(embed_config)
+                    if errors:
+                        flash('; '.join(errors), 'error')
+                        return redirect(url_for('notification_builder'))
                 
                 # Initialize flows list if it doesn't exist
                 if 'notification_flows' not in config:
@@ -337,10 +257,13 @@ def init_routes(app):
         if template_name:
             template_data = get_template(template_name)
         
+        prefill_flow = editing_flow if edit_index is not None else (template_data or {})
+
         return render_template('builder.html', 
                              webhook_url=config.get('discord_webhook', ''),
                              flows=config.get('notification_flows', []),
                              editing_flow=editing_flow,
+                             prefill_flow=prefill_flow,
                              edit_index=edit_index,
                              config=config,
                              template_data=template_data,
@@ -397,6 +320,7 @@ def init_routes(app):
     @app.route('/test_flow', methods=['POST'])
     def test_flow():
         try:
+            config = get_config()
             # Parse embed configuration for test
             embed_config = {}
             if request.form.get('embed_enabled') == 'true':

--- a/functions/auth.py
+++ b/functions/auth.py
@@ -1,0 +1,44 @@
+"""Optional API key authentication for mutating endpoints."""
+
+import os
+from functools import wraps
+
+from flask import jsonify, request
+
+
+def is_api_key_required():
+    """Return True when an API key is configured."""
+    return bool(os.environ.get('API_KEY', '').strip())
+
+
+def check_api_key():
+    """
+    Validate API key from X-API-Key header or api_key query param.
+    Returns None if authorized, or (response, status_code) if not.
+    """
+    if not is_api_key_required():
+        return None
+
+    expected = os.environ.get('API_KEY', '').strip()
+    provided = (
+        request.headers.get('X-API-Key')
+        or request.headers.get('Authorization', '').removeprefix('Bearer ').strip()
+        or request.args.get('api_key', '')
+    )
+
+    if provided != expected:
+        return jsonify({'error': 'Unauthorized', 'message': 'Valid API key required'}), 401
+    return None
+
+
+def require_api_key(f):
+    """Decorator for routes that require API key when API_KEY env is set."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth_error = check_api_key()
+        if auth_error:
+            return auth_error
+        return f(*args, **kwargs)
+
+    return decorated

--- a/functions/config.py
+++ b/functions/config.py
@@ -1,67 +1,82 @@
 import json
 import os
 import sys
+import fcntl
+from contextlib import contextmanager
 from datetime import datetime
 
+# Configuration paths (override with env vars)
+DATA_DIR = os.environ.get('DATA_DIR', 'data')
+CONFIG_FILE = os.environ.get('CONFIG_FILE', os.path.join(DATA_DIR, 'config.json'))
+LOG_FILE = os.environ.get('LOG_FILE', os.path.join(DATA_DIR, 'notification_logs.json'))
+LOCK_FILE = CONFIG_FILE + '.lock'
 
 
-# Configuration files
-CONFIG_FILE = 'data/config.json'
-LOG_FILE = 'data/notification_logs.json'
+@contextmanager
+def _config_lock(shared=False):
+    """File-based lock for config read/write operations."""
+    os.makedirs(os.path.dirname(CONFIG_FILE) or '.', exist_ok=True)
+    with open(LOCK_FILE, 'w') as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_SH if shared else fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
 
 def initialize_files():
     """Initialize config and log files if they don't exist"""
-    # Ensure data directory exists
     data_dir = os.path.dirname(CONFIG_FILE)
-    if not os.path.exists(data_dir):
+    if data_dir and not os.path.exists(data_dir):
         os.makedirs(data_dir, exist_ok=True)
-    
-    # Initialize default config if file doesn't exist
-    if not os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, 'w') as f:
-            json.dump({
-                "discord_webhook": "",
-                "check_interval": 5,
-                "log_retention": 1000,
-                "notification_log_retention": 500,
-                "user_variables": {},
-                "total_notifications_sent": 0
-            }, f)
 
-    # Initialize log file if it doesn't exist
+    if not os.path.exists(CONFIG_FILE):
+        with _config_lock():
+            with open(CONFIG_FILE, 'w') as f:
+                json.dump({
+                    "discord_webhook": "",
+                    "check_interval": 5,
+                    "log_retention": 1000,
+                    "notification_log_retention": 500,
+                    "user_variables": {},
+                    "total_notifications_sent": 0
+                }, f)
+
     if not os.path.exists(LOG_FILE):
         with open(LOG_FILE, 'w') as f:
             json.dump([], f)
 
+
 def get_config():
     """Get configuration from file"""
-    with open(CONFIG_FILE, 'r') as f:
-        config = json.load(f)
+    with _config_lock(shared=True):
+        with open(CONFIG_FILE, 'r') as f:
+            config = json.load(f)
     if 'user_variables' not in config:
         config['user_variables'] = {}
     return config
 
+
 def save_config(config):
     """Save configuration to file with proper serialization."""
-    
-    # Prepare a serializable copy first (convert any complex last_data to string)
-    config_copy = config.copy()
+
+    config_copy = json.loads(json.dumps(config))
+
     for flow in config_copy.get('notification_flows', []):
         if 'last_data' in flow and not isinstance(flow['last_data'], str):
             try:
                 flow['last_data'] = json.dumps(flow['last_data'])
             except Exception:
-                # If it cannot be serialized, drop it rather than breaking saves
                 flow['last_data'] = ""
-    
-    # Ensure data directory exists
-    os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
-    
-    # Simple atomic write using temporary file
-    tmp_path = CONFIG_FILE + '.tmp'
-    with open(tmp_path, 'w') as tf:
-        json.dump(config_copy, tf, indent=4)
-    os.replace(tmp_path, CONFIG_FILE)
+
+    os.makedirs(os.path.dirname(CONFIG_FILE) or '.', exist_ok=True)
+
+    with _config_lock():
+        tmp_path = CONFIG_FILE + '.tmp'
+        with open(tmp_path, 'w') as tf:
+            json.dump(config_copy, tf, indent=4)
+        os.replace(tmp_path, CONFIG_FILE)
+
 
 def get_logs():
     """Get logs from the separate log file"""
@@ -71,56 +86,50 @@ def get_logs():
     except (FileNotFoundError, json.JSONDecodeError):
         return []
 
+
 def save_logs(logs):
     """Save logs to the separate log file"""
     with open(LOG_FILE, 'w') as f:
         json.dump(logs, f, indent=2)
 
+
 def clear_logs():
     """Clear all logs"""
     save_logs([])
 
+
 def get_log_stats(category=None):
     """Get log statistics, optionally filtered by category"""
     logs = get_logs()
-    
-    # Filter by category if specified
+
     if category:
         logs = [log for log in logs if log.get('category', 'General') == category]
-    
-    # Get category breakdown
+
     all_logs = get_logs()
     category_counts = {}
     for log in all_logs:
         cat = log.get('category', 'General')
         category_counts[cat] = category_counts.get(cat, 0) + 1
-    
+
     return {
         'total_logs': len(logs),
         'oldest_log': logs[0]['timestamp'] if logs else None,
         'newest_log': logs[-1]['timestamp'] if logs else None,
         'category_counts': category_counts,
         'filtered_category': category
-    } 
+    }
+
 
 def increment_notification_counter():
-    """Simple function to increment total_notifications_sent by 1"""
-    print("Incrementing notification counter")
+    """Increment total_notifications_sent by 1 using locked read-modify-write."""
     try:
-        with open(CONFIG_FILE, 'r') as f:
-            config = json.load(f)
-        
-        current_total = config.get('total_notifications_sent', 0)
-        config['total_notifications_sent'] = current_total + 1
-        
-        # Use atomic write like save_config
-        tmp_path = CONFIG_FILE + '.tmp'
-        with open(tmp_path, 'w') as tf:
-            json.dump(config, tf, indent=4)
-        os.replace(tmp_path, CONFIG_FILE)
-
-        print(f"Notification counter incremented to {config['total_notifications_sent']}")
-            
+        with _config_lock():
+            with open(CONFIG_FILE, 'r') as f:
+                config = json.load(f)
+            config['total_notifications_sent'] = config.get('total_notifications_sent', 0) + 1
+            tmp_path = CONFIG_FILE + '.tmp'
+            with open(tmp_path, 'w') as tf:
+                json.dump(config, tf, indent=4)
+            os.replace(tmp_path, CONFIG_FILE)
     except Exception as e:
-        # If something goes wrong, just log it and continue
-        print(f"Failed to increment notification counter: {e}")
+        print(f"Failed to increment notification counter: {e}", file=sys.stderr)

--- a/functions/flow_stats.py
+++ b/functions/flow_stats.py
@@ -51,22 +51,26 @@ def get_flow_usage_from_logs(logs):
         timestamp = log.get('timestamp', '')
         
         # Parse different types of log messages
-        if 'Timer trigger: Sending notification for flow' in message:
+        if any(token in message for token in (
+            'Scheduled monitoring: Running check for flow',
+            'Timer trigger: Sending notification for flow',
+            'Timer triggered for flow',
+        )):
             flow_name = extract_flow_name_from_message(message)
             if flow_name:
                 update_flow_stats(flow_stats, flow_name, 'timer', timestamp)
-                
-        elif 'Change detected: Field' in message and 'in flow' in message:
+
+        elif 'Change detected: Field' in message and "in flow" in message:
             flow_name = extract_flow_name_from_message(message)
             if flow_name:
                 update_flow_stats(flow_stats, flow_name, 'change', timestamp)
-                
+
         elif 'Webhook received: Processing webhook for flow' in message:
             flow_name = extract_flow_name_from_message(message)
             if flow_name:
                 update_flow_stats(flow_stats, flow_name, 'webhook', timestamp)
-                
-        elif 'Test notification sent for' in message:
+
+        elif 'Test notification:' in message or 'Test notification sent for' in message:
             flow_name = extract_flow_name_from_message(message)
             if flow_name:
                 update_flow_stats(flow_stats, flow_name, 'test', timestamp)
@@ -161,7 +165,7 @@ def get_recent_flow_activity(hours=24):
                             recent_activity[flow_name] = []
                         
                         activity_type = 'unknown'
-                        if 'Timer trigger' in message:
+                        if 'Scheduled monitoring' in message or 'Timer trigger' in message:
                             activity_type = 'timer'
                         elif 'Change detected' in message:
                             activity_type = 'change'

--- a/functions/form_parsers.py
+++ b/functions/form_parsers.py
@@ -1,0 +1,206 @@
+"""Shared parsers for flow and embed configuration from forms or JSON."""
+
+import secrets
+
+
+def parse_embed_fields(form):
+    """Parse static embed fields from a form-like mapping."""
+    fields = []
+
+    def getlist(key):
+        if hasattr(form, 'getlist'):
+            return form.getlist(key)
+        value = form.get(key, []) if isinstance(form, dict) else []
+        return value if isinstance(value, list) else ([value] if value else [])
+
+    def get(key, default=''):
+        if hasattr(form, 'get'):
+            return form.get(key, default)
+        return form.get(key, default) if isinstance(form, dict) else default
+
+    names = getlist('embed_field_name[]')
+    values = getlist('embed_field_value[]')
+
+    for index, (name, value) in enumerate(zip(names, values)):
+        if name and value:
+            inline = get(f'embed_field_inline_{index}', '') in ('true', 'on', '1', True)
+            fields.append({
+                'name': name,
+                'value': value,
+                'inline': inline,
+            })
+    return fields
+
+
+def parse_embed_config_from_form(form):
+    """Parse embed configuration from a Flask form or dict-like object."""
+
+    def get(key, default=''):
+        if hasattr(form, 'get'):
+            return form.get(key, default)
+        return form.get(key, default) if isinstance(form, dict) else default
+
+    def getlist(key):
+        if hasattr(form, 'getlist'):
+            return form.getlist(key)
+        value = form.get(key, []) if isinstance(form, dict) else []
+        return value if isinstance(value, list) else ([value] if value else [])
+
+    if get('embed_enabled') not in ('true', True):
+        return {}
+
+    color_mode = get('embed_color_mode', 'static')
+    embed_config = {
+        'enabled': True,
+        'title': get('embed_title', ''),
+        'description': get('embed_description', ''),
+        'url': get('embed_url', ''),
+        'color_mode': color_mode,
+        'timestamp': get('embed_timestamp', 'true') == 'true',
+        'footer_text': get('embed_footer_text', ''),
+        'footer_icon': get('embed_footer_icon', ''),
+        'author_name': get('embed_author_name', ''),
+        'author_icon': get('embed_author_icon', ''),
+        'author_url': get('embed_author_url', ''),
+        'thumbnail_url': get('embed_thumbnail_url', ''),
+        'image_url': get('embed_image_url', ''),
+        'fields': parse_embed_fields(form),
+        'dynamic_fields': [],
+    }
+
+    if color_mode == 'static':
+        embed_config['color'] = get('embed_color', '')
+    elif color_mode == 'if':
+        embed_config['color_monitor'] = get('embed_color_monitor', '')
+        tests = getlist('embed_color_if_test[]')
+        colors = getlist('embed_color_if_color[]')
+        rules = []
+        for test, color in zip(tests, colors):
+            if test and color:
+                rules.append({'test': test, 'color': color})
+        embed_config['color_rules'] = rules
+    elif color_mode == 'gradient':
+        embed_config['color_monitor'] = get('embed_color_monitor', '')
+        embed_config['gradient'] = {
+            'start_value': get('embed_gradient_start_value', ''),
+            'start_color': get('embed_gradient_start_color', '#00ff00'),
+            'end_value': get('embed_gradient_end_value', ''),
+            'end_color': get('embed_gradient_end_color', '#ff0000'),
+        }
+
+    return embed_config
+
+
+def parse_api_headers(form):
+    """Parse custom API headers from form data."""
+
+    def getlist(key):
+        if hasattr(form, 'getlist'):
+            return form.getlist(key)
+        value = form.get(key, []) if isinstance(form, dict) else []
+        return value if isinstance(value, list) else ([value] if value else [])
+
+    headers = []
+    keys = getlist('header_key[]')
+    values = getlist('header_value[]')
+    for key, value in zip(keys, values):
+        if key:
+            headers.append({'key': key, 'value': value})
+    return headers
+
+
+def build_flow_from_form(form, editing_flow=None):
+    """Build a flow dict from submitted form data."""
+
+    def get(key, default=''):
+        return form.get(key, default)
+
+    trigger_type = get('trigger_type', 'on_change')
+    webhook_url = get('webhook_url', '').strip()
+    accept_webhooks = trigger_type == 'webhook'
+    require_webhook_secret = get('require_webhook_secret', 'false') == 'true'
+
+    embed_config = parse_embed_config_from_form(form)
+
+    flow = {
+        'name': get('flow_name'),
+        'trigger_type': trigger_type,
+        'webhook_url': webhook_url,
+        'webhook_name': get('webhook_name', '').strip(),
+        'webhook_avatar': get('webhook_avatar', '').strip(),
+        'message_template': get('message_template', ''),
+        'active': get('active', 'false') == 'true',
+        'endpoint': get('endpoint', ''),
+        'field': get('field', ''),
+        'interval': int(get('interval', 5) or 5) if trigger_type == 'timer' else None,
+        'accept_webhooks': accept_webhooks,
+        'embed_config': embed_config,
+        'category': get('category', 'General'),
+        'condition_enabled': get('condition_enabled', 'false') == 'true',
+        'condition': get('condition', ''),
+        'api_headers': parse_api_headers(form),
+        'api_request_body': get('api_request_body', ''),
+    }
+
+    if accept_webhooks and require_webhook_secret:
+        if editing_flow and editing_flow.get('webhook_secret'):
+            flow['webhook_secret'] = editing_flow['webhook_secret']
+        else:
+            flow['webhook_secret'] = secrets.token_urlsafe(16)
+
+    if editing_flow:
+        for key in ('last_value', 'last_run', 'last_data'):
+            if key in editing_flow:
+                flow[key] = editing_flow[key]
+
+    return flow
+
+
+def build_flow_from_json(data, existing_flow=None):
+    """Build a flow dict from JSON API payload."""
+
+    if not isinstance(data, dict):
+        raise ValueError('Request body must be a JSON object')
+
+    name = (data.get('name') or '').strip()
+    if not name:
+        raise ValueError('Flow name is required')
+
+    trigger_type = data.get('trigger_type', 'on_change')
+    if trigger_type not in ('timer', 'on_change', 'webhook'):
+        raise ValueError('Invalid trigger_type')
+
+    flow = {
+        'name': name,
+        'trigger_type': trigger_type,
+        'webhook_url': data.get('webhook_url', ''),
+        'webhook_name': data.get('webhook_name', ''),
+        'webhook_avatar': data.get('webhook_avatar', ''),
+        'message_template': data.get('message_template', ''),
+        'active': bool(data.get('active', True)),
+        'endpoint': data.get('endpoint', ''),
+        'field': data.get('field', ''),
+        'interval': data.get('interval', 5) if trigger_type == 'timer' else None,
+        'accept_webhooks': trigger_type == 'webhook',
+        'embed_config': data.get('embed_config', {}),
+        'category': data.get('category', 'General'),
+        'condition_enabled': bool(data.get('condition_enabled', False)),
+        'condition': data.get('condition', ''),
+        'api_headers': data.get('api_headers', []),
+        'api_request_body': data.get('api_request_body', ''),
+    }
+
+    if trigger_type == 'webhook' and data.get('require_webhook_secret'):
+        if existing_flow and existing_flow.get('webhook_secret'):
+            flow['webhook_secret'] = existing_flow['webhook_secret']
+        else:
+            flow['webhook_secret'] = secrets.token_urlsafe(16)
+    elif existing_flow and existing_flow.get('webhook_secret') and data.get('keep_webhook_secret'):
+        flow['webhook_secret'] = existing_flow['webhook_secret']
+
+    if existing_flow:
+        for key in ('last_value', 'last_run', 'last_data'):
+            if key in existing_flow and key not in data:
+                flow[key] = existing_flow[key]
+
+    return flow

--- a/functions/notifications.py
+++ b/functions/notifications.py
@@ -319,6 +319,8 @@ def check_endpoints():
     max_consecutive_errors = 5
     consecutive_errors = 0
     base_retry_delay = 1  # Start with 1 second delay
+    last_no_change_log = {}
+    no_change_log_interval = 3600  # Log unchanged values at most once per hour per flow
     
     while True:
         try:
@@ -331,7 +333,7 @@ def check_endpoints():
                     continue 
                 try:
                     # Skip webhook-triggered flows
-                    if flow['trigger_type'] == 'on_incoming':
+                    if flow['trigger_type'] in ('webhook', 'on_incoming'):
                         continue
                     
                     # Get API data if endpoint is configured
@@ -409,7 +411,13 @@ def check_endpoints():
                             else:
                                 log_notification(f"❌ Failed to send notification for flow '{flow['name']}', last_value not updated")
                         else:
-                            log_notification(f"🔄 No change detected: Field '{flow['field']}' value '{current_value}' unchanged in flow '{flow['name']}'")
+                            flow_name = flow['name']
+                            now = time.time()
+                            if now - last_no_change_log.get(flow_name, 0) >= no_change_log_interval:
+                                last_no_change_log[flow_name] = now
+                                log_notification(
+                                    f"🔄 No change detected: Field '{flow['field']}' value '{current_value}' unchanged in flow '{flow_name}'"
+                                )
                                 
                 except Exception as e:
                     log_notification(f"Error in flow {flow.get('name', 'unnamed')}: {str(e)}")

--- a/functions/utils.py
+++ b/functions/utils.py
@@ -473,10 +473,17 @@ def safe_eval_calculation(expression, variables):
         log_notification(f"Calculation error in '{expression}': {str(e)}")
         return f"CALC_ERROR({expression})"
 
-def evaluate_condition(condition, data):
+def evaluate_condition(condition, data, user_variables=None):
     """Safely evaluate a condition expression using AST instead of eval()"""
     if not condition or not condition.strip():
         return True
+
+    if user_variables is None:
+        try:
+            from functions.config import get_config
+            user_variables = get_config().get('user_variables', {})
+        except Exception:
+            user_variables = {}
     
     try:
         # Define safe operators

--- a/templates/builder.html
+++ b/templates/builder.html
@@ -12,7 +12,7 @@
         <div class="builder-left">
             <section class="panel builder">
                 <div class="panel-header builder-header">
-                    <h2 class="panel-title">{% if editing_flow %}Edit flow{% else %}New flow{% endif %}</h2>
+                    <h2 class="panel-title">{% if edit_index is not none %}Edit flow{% else %}New flow{% endif %}</h2>
                     <div class="builder-actions">
                         <a href="{{ url_for('show_templates') }}" class="btn-templates">Templates</a>
                         <a href="{{ url_for('show_flow_stats') }}" class="btn-stats">Statistics</a>
@@ -30,6 +30,9 @@
                 {% endwith %}
                 
                 <form method="post">
+                    {% set pf = prefill_flow if prefill_flow is defined else {} %}
+                    {% set tt = pf.get('trigger_type', 'on_change') %}
+                    {% set ec = pf.get('embed_config', {}) %}
                     <section class="builder-section">
                         <h3>Basic Information</h3>
                         <div class="form-group">
@@ -41,23 +44,23 @@
                         <div class="form-group">
                             <label for="flow_name">Flow Name:</label>
                             <input type="text" id="flow_name" name="flow_name" 
-                                   value="{{ editing_flow.name if editing_flow else (template_data.name if template_data else '') }}" required>
+                                   value="{{ pf.get('name', '') }}" required>
                         </div>
                         <div class="form-group">
                             <label for="category">Category:</label>
                             <select id="category" name="category">
-                                <option value="General" {% if editing_flow and editing_flow.category == 'General' %}selected{% endif %}>General</option>
-                                <option value="Media" {% if editing_flow and editing_flow.category == 'Media' %}selected{% endif %}>Media</option>
-                                <option value="System" {% if editing_flow and editing_flow.category == 'System' %}selected{% endif %}>System</option>
-                                <option value="Monitoring" {% if editing_flow and editing_flow.category == 'Monitoring' %}selected{% endif %}>Monitoring</option>
-                                <option value="Reports" {% if editing_flow and editing_flow.category == 'Reports' %}selected{% endif %}>Reports</option>
-                                <option value="Alerts" {% if editing_flow and editing_flow.category == 'Alerts' %}selected{% endif %}>Alerts</option>
+                                <option value="General" {% if pf.get('category', 'General') == 'General' %}selected{% endif %}>General</option>
+                                <option value="Media" {% if pf.get('category') == 'Media' %}selected{% endif %}>Media</option>
+                                <option value="System" {% if pf.get('category') == 'System' %}selected{% endif %}>System</option>
+                                <option value="Monitoring" {% if pf.get('category') == 'Monitoring' %}selected{% endif %}>Monitoring</option>
+                                <option value="Reports" {% if pf.get('category') == 'Reports' %}selected{% endif %}>Reports</option>
+                                <option value="Alerts" {% if pf.get('category') == 'Alerts' %}selected{% endif %}>Alerts</option>
                             </select>
                             <small>Organize your flows with categories</small>
                         </div>
                         <div class="form-group">
                             <label for="active">Active:</label>
-                            <input type="checkbox" id="active" name="active" value="true" {% if editing_flow and editing_flow.active %}checked{% endif %}>
+                            <input type="checkbox" id="active" name="active" value="true" {% if pf.get('active', True) %}checked{% endif %}>
                             <small>Enable or disable this flow</small>
                         </div>
                     </section>
@@ -69,12 +72,12 @@
                         <div class="form-group">
                             <label for="endpoint">API Endpoint:</label>
                             <input type="url" id="endpoint" name="endpoint" 
-                                   value="{{ editing_flow.endpoint if editing_flow else '' }}"
+                                   value="{{ pf.get('endpoint', '') }}"
                                    placeholder="https://api.example.com/data">
                             <small>Optional for timer triggers, required for change detection</small>
                             <label for="field">Field to Use:</label>
                             <input type="text" id="field" name="field" 
-                                   value="{{ editing_flow.field if editing_flow else '' }}"
+                                   value="{{ pf.get('field', '') }}"
                                    placeholder="result['0']['web_title']">
                             <small>Field to monitor for changes. Supports bracket notation like result['0']['web_title'] (required for change detection)</small>
                         </div>
@@ -106,7 +109,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="api_request_body">Request Body:</label>
-                                <textarea id="api_request_body" name="api_request_body" rows="4" placeholder='{"key": "value"} or GraphQL query'>{{ editing_flow.api_request_body if editing_flow else '' }}</textarea>
+                                <textarea id="api_request_body" name="api_request_body" rows="4" placeholder='{"key": "value"} or GraphQL query'>{{ pf.get('api_request_body', '') }}</textarea>
                                 <small>
                                     <strong>Optional.</strong> If provided, a POST request will be made with this body. Otherwise, a GET request is used.
                                     <br><br>
@@ -125,19 +128,19 @@
                             <div class="radio-group">
                                 <label>
                                     <input type="radio" name="trigger_type" value="timer"
-                                           {% if editing_flow and editing_flow.trigger_type == 'timer' or (template_data and template_data.trigger_type == 'timer') %}checked{% endif %}> 
+                                           {% if tt == 'timer' %}checked{% endif %}> 
                                     <strong>Scheduled Monitoring</strong>
                                     <small>Regular checks at fixed intervals (good for reports, health checks, periodic updates)</small>
                                 </label>
                                 <label>
                                     <input type="radio" name="trigger_type" value="on_change"
-                                           {% if (not editing_flow and not template_data) or (editing_flow and editing_flow.trigger_type == 'on_change') or (template_data and template_data.trigger_type == 'on_change') %}checked{% endif %}> 
+                                           {% if tt == 'on_change' %}checked{% endif %}> 
                                     <strong>Change Detection</strong>
                                     <small>Immediate alerts when monitored values change (good for status changes, alerts, events)</small> 
                                 </label>
                                 <label>
                                     <input type="radio" name="trigger_type" value="webhook"
-                                           {% if editing_flow and editing_flow.trigger_type == 'webhook' %}checked{% endif %}> 
+                                           {% if tt == 'webhook' %}checked{% endif %}> 
                                     <strong>Incoming Webhook</strong>
                                     <small>Responds to incoming webhook calls from external services</small>
                                 </label>
@@ -181,7 +184,7 @@
                         <div class="form-group" id="timer-options" style="display: none;">
                             <label for="interval">Interval (minutes):</label>
                             <input type="number" id="interval" name="interval" min="1" 
-                                   value="{{ editing_flow.interval if editing_flow else '5' }}" required>
+                                   value="{{ pf.get('interval', 5) }}" required>
                         </div>
                         <div class="form-group">
                             <label>
@@ -226,18 +229,18 @@
                         <div class="form-group">
                             <label for="webhook_name">Webhook Name:</label>
                             <input type="text" id="webhook_name" name="webhook_name" 
-                                   value="{{ editing_flow.webhook_name if editing_flow else (template_data.webhook_name if template_data else '') }}"
+                                   value="{{ pf.get('webhook_name', '') }}"
                                    placeholder="{{ config.default_webhook_name if config.default_webhook_name else 'Notification Bot' }}">
                         </div>
                         <div class="form-group">
                             <label for="webhook_avatar">Webhook Avatar URL:</label>
                             <input type="url" id="webhook_avatar" name="webhook_avatar" 
-                                   value="{{ editing_flow.webhook_avatar if editing_flow else '' }}"
+                                   value="{{ pf.get('webhook_avatar', '') }}"
                                    placeholder="{{ config.default_webhook_avatar if config.default_webhook_avatar else 'https://example.com/avatar.png' }}">
                         </div>
                         <div class="form-group">
                             <label for="message_template">Message Template:</label>
-                            <textarea id="message_template" name="message_template" rows="3">{{ editing_flow.message_template if editing_flow else (template_data.message_template if template_data else '') }}</textarea>
+                            <textarea id="message_template" name="message_template" rows="3">{{ pf.get('message_template', '') }}</textarea>
                             <small>
                                 Available variables: 
                                 {value} - Current field value, 
@@ -275,7 +278,7 @@
                         <div class="form-group">
                             <label>
                                 <input type="checkbox" name="embed_enabled" id="embed_enabled" value="true"
-                                       {% if editing_flow and editing_flow.embed_config and editing_flow.embed_config.enabled %}checked{% endif %}> 
+                                       {% if ec.get('enabled') %}checked{% endif %}> 
                                 Enable Discord Embed
                             </label>
                             <small>Embeds provide rich formatting with colors, images, fields, and more</small>
@@ -442,13 +445,26 @@
                             <div class="form-group">
                                 <label for="embed_image_url">Main Image URL:</label>
                                 <input type="url" id="embed_image_url" name="embed_image_url" 
-                                       value="{{ editing_flow.embed_config.image_url if editing_flow and editing_flow.embed_config else '' }}"
+                                       value="{{ ec.get('image_url', '') }}"
                                        placeholder="https://example.com/image.png">
                                 <small>Large image at the bottom of the embed</small>
                             </div>
+
+                            <h4>Embed Fields</h4>
+                            <p class="page-description" style="margin-bottom: 0.75rem;">Add optional name/value rows shown inside the Discord embed.</p>
+                            <div id="embed-fields-list" class="field-group">
+                                {% for field in ec.get('fields', []) %}
+                                <div class="field-row embed-field-row">
+                                    <input type="text" name="embed_field_name[]" value="{{ field.name }}" placeholder="Field name">
+                                    <textarea name="embed_field_value[]" rows="2" placeholder="Field value">{{ field.value }}</textarea>
+                                    <label><input type="checkbox" name="embed_field_inline_{{ loop.index0 }}" value="true" {% if field.inline %}checked{% endif %}> Inline</label>
+                                    <button type="button" class="btn-remove-embed-field btn-remove">Remove</button>
+                                </div>
+                                {% endfor %}
+                            </div>
+                            <button type="button" id="add-embed-field" class="btn-secondary">Add embed field</button>
                             
-                            <small>💡 <strong>Tip:</strong> Use the embed title, description, and other fields above to create rich notifications. Template variables like {time}, {value}, and {data} work in all embed fields! Calculations like [{value} - {old_value}] also work!</small>
-                            <small>💡 <strong>Tip:</strong> Use the embed title, description, and other fields above to create rich notifications. Template variables like {time}, {value}, and {data} work in all embed fields! Calculations like [{value} - {old_value}] also work!</small>
+                            <small>💡 Template variables like {time}, {value}, and {data} work in all embed fields.</small>
                         </div>
                     </section>
                     
@@ -524,7 +540,10 @@
                     {% if flow.trigger_type == 'webhook' %}
                     <p><strong>Webhook URL:</strong> /api/webhook/{{ flow.name }}</p>
                     {% if flow.webhook_secret %}
-                    <p><strong>Webhook Secret:</strong> {{ flow.webhook_secret }}</p>
+                    <p><strong>Webhook Secret:</strong>
+                        <code class="secret-value" data-secret="{{ flow.webhook_secret }}">••••••••</code>
+                        <button type="button" class="btn-secondary btn-reveal-secret" style="padding:0.25rem 0.5rem; font-size:0.8rem;">Reveal</button>
+                    </p>
                     {% endif %}
                     {% endif %}
                     {% if flow.webhook_name %}
@@ -735,8 +754,52 @@
             }
             
             function loadExistingFields() {
-                // No longer needed - removed static/dynamic field functionality
+                const list = document.getElementById('embed-fields-list');
+                const addBtn = document.getElementById('add-embed-field');
+                if (!list || !addBtn) return;
+
+                let embedFieldIndex = list.querySelectorAll('.embed-field-row').length;
+
+                function addEmbedFieldRow(name = '', value = '', inline = false) {
+                    const index = embedFieldIndex++;
+                    const row = document.createElement('div');
+                    row.className = 'field-row embed-field-row';
+                    row.innerHTML = `
+                        <input type="text" name="embed_field_name[]" placeholder="Field name" value="${name.replace(/"/g, '&quot;')}">
+                        <textarea name="embed_field_value[]" rows="2" placeholder="Field value">${value}</textarea>
+                        <label><input type="checkbox" name="embed_field_inline_${index}" value="true" ${inline ? 'checked' : ''}> Inline</label>
+                        <button type="button" class="btn-remove-embed-field btn-remove">Remove</button>
+                    `;
+                    list.appendChild(row);
+                }
+
+                addBtn.addEventListener('click', function() {
+                    addEmbedFieldRow();
+                });
+
+                list.addEventListener('click', function(e) {
+                    if (e.target.classList.contains('btn-remove-embed-field')) {
+                        e.target.closest('.embed-field-row')?.remove();
+                    }
+                });
             }
+
+            document.querySelectorAll('.btn-reveal-secret').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    const code = this.previousElementSibling;
+                    if (!code || !code.dataset.secret) return;
+                    const revealed = code.dataset.revealed === 'true';
+                    if (revealed) {
+                        code.textContent = '••••••••';
+                        code.dataset.revealed = 'false';
+                        this.textContent = 'Reveal';
+                    } else {
+                        code.textContent = code.dataset.secret;
+                        code.dataset.revealed = 'true';
+                        this.textContent = 'Hide';
+                    }
+                });
+            });
         
             function updateTriggerOptions() {
                 const selectedTrigger = document.querySelector('input[name="trigger_type"]:checked')?.value || 'on_change';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the top 10 reliability/feature improvements plus several low-risk quick wins from the codebase audit.

## Bug fixes

- **Conditional notifications** — `evaluate_condition()` no longer references undefined `user_variables` (conditions now evaluate correctly)
- **Webhook trigger type** — monitor skips `webhook` flows (was checking obsolete `on_incoming`); statistics API counts webhooks correctly
- **Flow statistics** — log parsing matches real message formats (`Scheduled monitoring`, `Webhook received`, etc.)
- **`test_flow`** — loads config before using default webhook URL
- **Webhook handler** — adds missing `sys` import for payload size check

## Infrastructure

- **Monitor thread** starts on app import (works in Docker without relying only on `__main__`)
- **Config file locking** via `fcntl` for safer concurrent reads/writes
- **`SECRET_KEY`** from env or persisted `data/.secret_key`
- **`DATA_DIR` / `CONFIG_FILE`** env var support
- **Docker HEALTHCHECK** on `/api/health`
- Throttled "no change detected" logs (max once/hour per flow)

## API (new)

| Endpoint | Description |
|----------|-------------|
| `POST /api/flows` | Create flow |
| `PUT /api/flows/<name>` | Update flow |
| `DELETE /api/flows/<name>` | Delete flow |
| `POST /api/flows/<name>/toggle` | Enable/disable |

Set `API_KEY` env var to require `X-API-Key` on mutating API routes. When unset, API remains open (backward compatible).

## Builder / UI

- **Template prefill** — templates now populate trigger type, category, endpoint, embed config, etc.
- **Embed fields UI** restored (add/remove rows)
- **Webhook secrets** masked with reveal button in sidebar
- Shared `form_parsers` module + embed validation on save

## CI

- New `.github/workflows/tests.yml` runs pytest on push/PR

## Notes

- Web UI routes (`/toggle_flow`, `/test_flow`) remain unauthenticated so the browser UI keeps working; API key only applies to `/api/*` mutating endpoints when configured.
- Test suite: 120 passed / 52 failed — remaining failures are pre-existing test isolation/import issues, not introduced by this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec5c4da1-246d-447b-85b6-b516b36a1fc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec5c4da1-246d-447b-85b6-b516b36a1fc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

